### PR TITLE
feat: adds a zIndex for table headers and open controls

### DIFF
--- a/src/zIndex/zIndex.json
+++ b/src/zIndex/zIndex.json
@@ -17,6 +17,9 @@
     },
     "overlay": {
       "value": 1000
+    },
+    "openControl": {
+      "value": "{zIndex.overlay.value}"
     }
   }
 }

--- a/src/zIndex/zIndex.json
+++ b/src/zIndex/zIndex.json
@@ -1,5 +1,8 @@
 {
   "zIndex": {
+    "modalHeaderAndFooter": {
+      "value": 2
+    },
     "tableHeader": {
       "value": 10
     },


### PR DESCRIPTION
This is part of the fix for `DatePicker` component overlapping a Modal's header and footer, if placed inside one. 