### PR TITLE
feat: add new z-index

### DIFF
--- a/src/zIndices/zIndices.json
+++ b/src/zIndices/zIndices.json
@@ -24,6 +24,9 @@
     "overlay": {
       "value": 1000
     },
+    "aboveOverlay": {
+      "value": 1010
+    },
     "openControl": {
       "value": "{zIndices.overlay.value}"
     }


### PR DESCRIPTION
This PR adds a new z-index token to be used for elements that are outside of the Modal or the sidebar that need to show above the overlay, for example: an `<Alert />` or a `<Toast />` component.